### PR TITLE
feat: Add a Helm chart for fuseml installer

### DIFF
--- a/fuseml/.helmignore
+++ b/fuseml/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/fuseml/Chart.yaml
+++ b/fuseml/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: fuseml
+description: Set up [FuseML](http://fuseml.github.io/) in your Kubernetes cluster
+
+type: application
+
+version: 0.1.0
+appVersion: "v0.2.1"

--- a/fuseml/README.md
+++ b/fuseml/README.md
@@ -1,0 +1,7 @@
+This charts runs the fuseml-installer in your cluster.
+
+By default it installs [FuseML](fuseml.github.io), but you can provide alternative commands to do anything what [fuseml-installer](https://github.com/fuseml/fuseml) accepts.
+
+```
+helm install fuseml . --namespace fuseml-installer --create-namespace --set systemDomain=example.com  --set extensions='{mlflow,cert-manager}'
+```

--- a/fuseml/templates/NOTES.txt
+++ b/fuseml/templates/NOTES.txt
@@ -1,0 +1,12 @@
+Please wait for several minutes for FuseML deployment to complete.
+{{ "" }}
+{{- if .Release.IsInstall }}
+
+Download FuseML client from https://github.com/fuseml/fuseml-core/releases.
+
+To use the FuseML CLI, you must point it to the FuseML server URL, e.g.:
+
+export FUSEML_SERVER_URL=http://$(kubectl get VirtualService -n fuseml-core fuseml-core -o jsonpath="{.spec.hosts[0]}")
+
+Find more in the FuseML documentation and tutorials at https://fuseml.github.io/docs/
+{{- end }}

--- a/fuseml/templates/_helpers.tpl
+++ b/fuseml/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fuseml.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fuseml.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fuseml.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fuseml.labels" -}}
+helm.sh/chart: {{ include "fuseml.chart" . }}
+{{ include "fuseml.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fuseml.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fuseml.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fuseml.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "fuseml.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/fuseml/templates/clusterrolebinding.yaml
+++ b/fuseml/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "fuseml.serviceAccountName" . }}-admin
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "fuseml.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+{{- end }}

--- a/fuseml/templates/delete-job.yaml
+++ b/fuseml/templates/delete-job.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "fuseml.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+  labels:
+    {{- include "fuseml.labels" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "fuseml.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "fuseml.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-uninstall
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- $args := list "uninstall" }}
+          {{- if .Values.extensionsRepository }}
+          {{-   $args = concat $args (list "--extensions-repository" .Values.extensionsRepository) }}
+          {{- end }}
+          {{- if .Values.systemDomain }}
+          {{-   $args = concat $args (list "--system-domain" .Values.systemDomain) }}
+          {{- end }}
+          {{- range .Values.extensions }}
+          {{-   $args = concat $args (list "--extensions" .) }}
+          {{- end }}
+          args:
+          {{- range $args }}
+            - {{ . }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+      restartPolicy: Never
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  backoffLimit: 0

--- a/fuseml/templates/job.yaml
+++ b/fuseml/templates/job.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "fuseml.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fuseml.labels" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "fuseml.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "fuseml.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- $args := list .Values.installerCmd }}
+          {{- if .Values.extensionsRepository }}
+          {{-   $args = concat $args (list "--extensions-repository" .Values.extensionsRepository) }}
+          {{- end }}
+          {{- if .Values.systemDomain }}
+          {{-   $args = concat $args (list "--system-domain" .Values.systemDomain) }}
+          {{- end }}
+          {{- range .Values.extensions }}
+          {{-   $args = concat $args (list "--extensions" .) }}
+          {{- end }}
+          args:
+          {{- range $args }}
+            - {{ . }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+      restartPolicy: Never
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  backoffLimit: 0

--- a/fuseml/templates/serviceaccount.yaml
+++ b/fuseml/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fuseml.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fuseml.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/fuseml/values.yaml
+++ b/fuseml/values.yaml
@@ -1,0 +1,34 @@
+image:
+  repository: ghcr.io/fuseml/fuseml-installer
+  pullPolicy: Always
+  tag:
+
+# main command to pass to the installer
+installerCmd: "install"
+
+# Path (URL) to custom repository with FuseML extensions
+extensionsRepository:
+
+# List of extensions to install
+extensions: []
+
+# The domain for Fuseml. Should be pointing to the load balancer public IP.
+systemDomain:
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: "fuseml-installer"
+
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
Installing this Helm chart will install fuseml into the same
K8s cluster. By default it runs the 'install' command of fuseml-installer

Using values.yaml it is possible to specify extensions that
should be installed together with the core services.